### PR TITLE
Bug fixes

### DIFF
--- a/customadmin/utilities/cloudinarymigrator.cfm
+++ b/customadmin/utilities/cloudinarymigrator.cfm
@@ -18,7 +18,11 @@
 	<cfif not findnocase("//res.cloudinary.com/",stObj[url.copy_property])>
 		<cfif application.fc.lib.cdn.ioFileExists(location="images",file=stObj[url.copy_property])>
 			<cfset stFile = application.formtools.image.oFactory.uploadToCloudinary(file=stObj[url.copy_property]) />
+			<cfif isStruct(stFile)>
 			<cfset stObj[url.copy_property] = mid(stFile.url,6,len(stFile.url)) & "?source=#urlencodedformat(stObj[url.copy_property])#" />
+			<cfelse>
+				<cfset stObj[url.copy_property] = stFile />
+			</cfif>
 			
 			<cfset application.fapi.setData(stProperties=stObj) />
 			

--- a/customadmin/utilities/cloudinarymigrator.cfm
+++ b/customadmin/utilities/cloudinarymigrator.cfm
@@ -19,7 +19,7 @@
 		<cfif application.fc.lib.cdn.ioFileExists(location="images",file=stObj[url.copy_property])>
 			<cfset stFile = application.formtools.image.oFactory.uploadToCloudinary(file=stObj[url.copy_property]) />
 			<cfif isStruct(stFile)>
-			<cfset stObj[url.copy_property] = mid(stFile.url,6,len(stFile.url)) & "?source=#urlencodedformat(stObj[url.copy_property])#" />
+				<cfset stObj[url.copy_property] = mid(stFile.url,6,len(stFile.url)) & "?source=#urlencodedformat(stObj[url.copy_property])#" />
 			<cfelse>
 				<cfset stObj[url.copy_property] = stFile />
 			</cfif>
@@ -123,13 +123,13 @@
 						if (data.success){
 							$j("##file-"+(processingfile+1))
 								.removeClass("selected")
-								.find("input[name=files]").attr("checked",null).end()
+								.find("input[name=files]").prop("checked",null).end()
 								.find(".status").removeClass("status-not-applicable").removeClass("status-success").removeClass("status-failure").addClass("status-success").html("Done").attr("title","").end();
 						}
 						else{
 							$j("##file-"+(processingfile+1))
 								.removeClass("selected")
-								.find("input[name=files]").attr("checked",null).end()
+								.find("input[name=files]").prop("checked",null).end()
 								.find(".status").removeClass("status-not-applicable").removeClass("status-success").removeClass("status-failure").addClass("status-failure").html("Error").attr("title",data.error).end();
 						}
 						

--- a/customadmin/utilities/cloudinarymigrator.cfm
+++ b/customadmin/utilities/cloudinarymigrator.cfm
@@ -145,9 +145,9 @@
 </cfoutput>
 <skin:onReady><cfoutput>
 	$j("##allfiles").click(function(){
-		var tr = $j("##files tbody input[name=files]").attr("checked",$j(this).attr("checked")==="checked"?"checked":null).parents("tr.file");
+		var tr = $j("##files tbody input[name=files]").prop("checked",$j(this).prop("checked")?"checked":null).parents("tr.file");
 		
-		if ($j(this).attr("checked")==="checked")
+		if ($j(this).prop("checked"))
 			tr.addClass("selected");
 		else
 			tr.removeClass("selected")
@@ -156,9 +156,9 @@
 		var target = $j(event.target), input = $j("input[name=files]",this), self = $j(this);
 		
 		if (!target.is("input"))
-			input.attr("checked",input.attr("checked")==="checked"?null:"checked");
+			input.prop("checked",input.prop("checked")?null:"checked");
 		
-		if (input.attr("checked") === "checked")
+		if (input.prop("checked"))
 			self.addClass("selected");
 		else
 			self.removeClass("selected");

--- a/packages/formtools/arrayupload.cfc
+++ b/packages/formtools/arrayupload.cfc
@@ -329,7 +329,11 @@
 						<cfelse>
 							<cfset stFile = application.formtools.image.oFactory.uploadToCloudinary(file=uploadFileName) />
 						</cfif>
-						<cfset uploadFileName = mid(stFile.url,6,len(stFile.url)) & "?source=#urlencodedformat(uploadFileName)#" />
+						<cfif isStruct(stFile)>
+							<cfset uploadFileName = mid(stFile.url,6,len(stFile.url)) & "?source=#urlencodedformat(uploadFileName)#" />
+						<cfelse>
+							<cfset uploadFileName = stFile />
+						</cfif>
 						
 						<cfset stResult = passed(uploadFileName) />
 						<cfset stResult.bChanged = true />
@@ -348,7 +352,11 @@
 						
 						<!--- Copy to Cloudinary --->
 						<cfset stFile = application.formtools.image.oFactory.uploadToCloudinary(uploadFileName) />
-						<cfset uploadFileName = mid(stFile.url,6,len(stFile.url)) & "?source=#urlencodedformat(uploadFileName)#" />
+						<cfif isStruct(stFile)>
+							<cfset uploadFileName = mid(stFile.url,6,len(stFile.url)) & "?source=#urlencodedformat(uploadFileName)#" />
+						<cfelse>
+							<cfset uploadFileName = stFile />
+						</cfif>
 						
 						<cfset stResult = passed(uploadFileName) />
 						<cfset stResult.bChanged = true />

--- a/packages/formtools/image.cfc
+++ b/packages/formtools/image.cfc
@@ -176,12 +176,15 @@
 				<!--- This means there is already a file associated with this object. The new file must have the same name. --->
 				<cftry>
 					<cfset uploadFileName = application.fc.lib.cdn.ioUploadFile(location="images",destination=sourceFile,nameconflict="makeunique",field=arguments.uploadfield,sizeLimit=arguments.sizeLimit) />
-					
+					<cfset var origUploadFileName = uploadFileName />
 					<!--- Copy to Cloudinary --->
 					<cfif refindnocase("//res.cloudinary.com/",arguments.existingfile)>
 						<cfset uploadFileName = uploadToCloudinary(file=uploadFileName,publicID=application.fc.lib.cloudinary.getID(arguments.existingfile)) />
 					<cfelse>
 						<cfset uploadFileName = uploadToCloudinary(file=uploadFileName) />
+					</cfif>
+					<cfif isStruct(uploadFileName)>
+						<cfset uploadFileName = mid(uploadFileName.url,6,len(uploadFileName.url)) & "?source=#urlencodedformat(origUploadFileName)#" />
 					</cfif>
 					
 					<cfset stResult = passed(uploadFileName) />
@@ -198,9 +201,12 @@
 				<!--- There is no image currently so we simply upload the image and make it unique  --->
 				<cftry>
 					<cfset uploadFileName = application.fc.lib.cdn.ioUploadFile(location="images",destination=arguments.destination,nameconflict="makeunique",acceptextensions=arguments.allowedExtensions,field=arguments.uploadfield,sizeLimit=arguments.sizeLimit) />
-					
+					<cfset var origUploadFileName = uploadFileName />
 					<!--- Copy to Cloudinary --->
 					<cfset uploadFileName = uploadToCloudinary(uploadFileName) />
+					<cfif isStruct(uploadFileName)>
+						<cfset uploadFileName = mid(uploadFileName.url,6,len(uploadFileName.url)) & "?source=#urlencodedformat(origUploadFileName)#" />
+					</cfif>
 					
 					<cfset stResult = passed(uploadFileName) />
 					<cfset stResult.bChanged = true />
@@ -264,10 +270,14 @@
 					
 					<!--- Copy to cloudinary --->
 					<cfset uploadFileName = "#arguments.destination#/#uploadFileName#" />
+					<cfset var origUploadFileName = uploadFileName />
 					<cfif refindnocase("//res.cloudinary.com/",arguments.existingfile)>
 						<cfset uploadFileName = uploadtocloudinary(uploadFileName,application.fc.lib.cloudinary.getID(arguments.existingFile)) />
 					<cfelse>
 						<cfset uploadFileName = uploadtocloudinary(uploadFileName) />
+					</cfif>
+					<cfif isStruct(uploadFileName)>
+						<cfset uploadFileName = mid(uploadFileName.url,6,len(uploadFileName.url)) & "?source=#urlencodedformat(origUploadFileName)#" />
 					</cfif>
 					
 					<cfset stResult = passed(uploadFileName) />
@@ -285,8 +295,11 @@
 					<cfset stResult = failed(value=arguments.existingfile,message="#arguments.localfile# is not within the file size limit of #round(arguments.sizeLimit/1048576)#MB") />
 				<cfelseif listFindNoCase(arguments.allowedExtensions,listlast(arguments.localfile,"."))>
 					<cfset uploadFileName = application.fc.lib.cdn.ioMoveFile(source_localpath=arguments.localfile,dest_location="images",dest_file=arguments.destination & "/" & getFileFromPath(arguments.localfile),nameconflict="makeunique") />
-					
+					<cfset var origUploadFileName = uploadFileName />
 					<cfset uploadFileName = uploadtocloudinary(uploadFileName) />
+					<cfif isStruct(uploadFileName)>
+						<cfset uploadFileName = mid(uploadFileName.url,6,len(uploadFileName.url)) & "?source=#urlencodedformat(origUploadFileName)#" />
+					</cfif>
 					
 					<cfset stResult = passed(uploadFileName) />
 					<cfset stResult.bChanged = true />
@@ -407,7 +420,7 @@
 	</cffunction>
 	
 	
-	<cffunction name="uploadToCloudinary" access="public" output="false" returntype="string" hint="Uploads specified image to Cloudinary and returns Cloudinary image path">
+	<cffunction name="uploadToCloudinary" access="public" output="false" returntype="any" hint="Uploads specified image to Cloudinary and returns Cloudinary image path">
 		<cfargument name="file" type="string" required="true" />
 		<cfargument name="publicID" type="string" required="false" default="#listfirst(listlast(arguments.file,'/'),'.')#_#application.fapi.getUUID()#" />
 		<cfargument name="transformation" type="string" required="false" default="" />

--- a/packages/formtools/image.cfc
+++ b/packages/formtools/image.cfc
@@ -266,7 +266,7 @@
 					<cfset application.fc.lib.cdn.ioMoveFile(source_location="archive",source_file=archivedFile,dest_location="images",dest_file=sourceFile) />
 					<cfset stResult = failed(value=arguments.existingfile,message="#arguments.localfile# is not within the file size limit of #round(arguments.sizeLimit/1048576)#MB") />
 				<cfelseif listlast(sourcefile,".") eq listlast(arguments.localfile,".")>
-					<cfset application.fc.lib.cdn.ioMoveFile(source_localpath=arguments.localfile,dest_location="images",dest_file=arguments.destination & "/" & uploadFilenName) />
+					<cfset application.fc.lib.cdn.ioMoveFile(source_localpath=arguments.localfile,dest_location="images",dest_file=arguments.destination & "/" & uploadFileName) />
 					
 					<!--- Copy to cloudinary --->
 					<cfset uploadFileName = "#arguments.destination#/#uploadFileName#" />

--- a/packages/lib/cloudinary.cfc
+++ b/packages/lib/cloudinary.cfc
@@ -331,7 +331,7 @@
 		<cfargument name="publicID" type="string" required="true">
 		<cfargument name="transformation" type="string" required="true">
 
-		<cfset var sigTimestamp = DateDiff('s', CreateDate(1970,1,1), now())>
+		<cfset var sigTimestamp = DateDiff('s', dateconvert('utc2local', CreateDateTime(1970,1,1,0,0,0)), now())>
 		<cfset var sigSignature = "">
 		<cfset var stResult = structnew()>
 		<cfset var stResponse = structnew()>
@@ -371,7 +371,7 @@
 			<cfset stResult = deserializejson(stResponse.filecontent)>
 			<cfset stResult["urlWithSource"] = mid(stResult.url,6,len(stResult.url)) & "?source=#urlencodedformat(arguments.file)#">
 		</cfif>
-
+		
 		<cfreturn stResult>
 	</cffunction>
 

--- a/packages/lib/cloudinary.cfc
+++ b/packages/lib/cloudinary.cfc
@@ -357,11 +357,6 @@
 			<cfhttpparam type="file" name="file" file="#application.fc.lib.cdn.ioReadFile(location='images',file=arguments.file,datatype='image').source#">
 		</cfhttp>
 		
-		<cfif isjson(stResponse.filecontent)>
-			<cfset stResult = deserializejson(stResponse.filecontent)>
-			<cfset stResult["urlWithSource"] = mid(stResult.url,6,len(stResult.url)) & "?source=#urlencodedformat(arguments.file)#">
-		</cfif>
-		
 		<cfif stResponse.StatusCode neq "200 Ok">
 			<cfif structkeyexists(stResult,"error")>
 				<!--- Cloudinary threw error, returned information --->
@@ -372,6 +367,11 @@
 			</cfif>
 		</cfif>
 		
+		<cfif isjson(stResponse.filecontent)>
+			<cfset stResult = deserializejson(stResponse.filecontent)>
+			<cfset stResult["urlWithSource"] = mid(stResult.url,6,len(stResult.url)) & "?source=#urlencodedformat(arguments.file)#">
+		</cfif>
+
 		<cfreturn stResult>
 	</cffunction>
 

--- a/packages/lib/cloudinary.cfc
+++ b/packages/lib/cloudinary.cfc
@@ -473,7 +473,7 @@
 				<cfset fileURL = "http:" & fileURL>
 			</cfif>
 
-			<cfset fileURL = fetchURL & urlEncode(fileURL)>
+			<cfset fileURL = fetchURL & urlEncodedFormat(fileURL)>
 		</cfif>
 
 		<cfreturn fileURL />

--- a/system/dmCron/cloudinarymigration.cfm
+++ b/system/dmCron/cloudinarymigration.cfm
@@ -68,7 +68,11 @@
 	<cfif not findnocase("//res.cloudinary.com/",stObject[qWrong.property])>
 		<cfif application.fc.lib.cdn.ioFileExists(location="images",file=stObject[qWrong.property])>
 			<cfset stFile = application.formtools.image.oFactory.uploadToCloudinary(file=stObject[qWrong.property]) />
-			<cfset stObject[qWrong.property] = mid(stFile.url,6,len(stFile.url)) & "?source=#urlencodedformat(stObject[qWrong.property])#" />
+			<cfif isStruct(stFile)>
+				<cfset stObject[qWrong.property] = mid(stFile.url,6,len(stFile.url)) & "?source=#urlencodedformat(stObject[qWrong.property])#" />
+			<cfelse>
+				<cfset stObject[qWrong.property] = stFile />
+			</cfif>
 			
 			<cfset application.fapi.setData(stProperties=stObject) />
 			

--- a/system/dmCron/cloudinarymigrator.cfm
+++ b/system/dmCron/cloudinarymigrator.cfm
@@ -85,7 +85,11 @@
 		<cfif application.fc.lib.cdn.ioFileExists(location="images",file=stObject[qWrong.property])>
 			<cfset cleanPublicID = reReplace(left(listfirst(listlast(stObject[qWrong.property],'/'),'.'), 64), "[^-a-zA-z0-9_.()\[\]]", "", "all") & "_" & application.fapi.getUUID()>
 			<cfset stFile = application.formtools.image.oFactory.uploadToCloudinary(file=stObject[qWrong.property], publicID=cleanPublicID) />
-			<cfset stObject[qWrong.property] = mid(stFile.url,6,len(stFile.url)) & "?source=#urlencodedformat(stObject[qWrong.property])#" />
+			<cfif isStruct(stFile)>
+				<cfset stObject[qWrong.property] = mid(stFile.url,6,len(stFile.url)) & "?source=#urlencodedformat(stObject[qWrong.property])#" />
+			<cfelse>
+				<cfset stObject[qWrong.property] = stFile />
+			</cfif>
 			
 			<cfset application.fapi.setData(stProperties=stObject) />
 			


### PR DESCRIPTION
This PR fixes several issues I discovered trying to get the plugin to work properly on FarCry 7.2.9
- If you used this on a server that did not have its local time set to UTC, it would generate incorrect timestamps.  Converting the epoch start date to UTC fixes that problem.
- The error check for a non-200 response was happening after trying to deserialize the JSON result.  So if you did get an error, it didn't surface because it threw an error trying to deserialize a non-JSON string.  Swapping these fixes that issue.
- the `uploadToCloudinary` function in the image formtool was recently changed so that it sometimes returns a struct and sometimes returns a string.  In various places where it was used it seemed to expect one or the other.  I updated this to be able to handle either scenario.
- the "check all" checkbox in the migration tool was broken as it used `attr("checked")` instead of `prop("checked")`
- the migration tool also stopped migrating files after only a few were processed again due to an issue using `attr` instead of `prop` for the checked attribute.
