### PR TITLE
fix for : not positioned in the view stack as body or any

### DIFF
--- a/webskin/configCloudinary/displayPageReportImages.cfm
+++ b/webskin/configCloudinary/displayPageReportImages.cfm
@@ -2,6 +2,7 @@
 <!--- @@fuAlias: report-image --->
 <!--- @@cachestatus: -1 --->
 <!--- @@proxycachetimeout: -1 --->
+<!--- @@Viewstack: any --->
 
 <h1>Image Matrix Report </h1>
 

--- a/webskin/configCloudinary/displayPageReportRichText.cfm
+++ b/webskin/configCloudinary/displayPageReportRichText.cfm
@@ -2,6 +2,7 @@
 <!--- @@fuAlias: report-richtext --->
 <!--- @@cachestatus: -1 --->
 <!--- @@proxycachetimeout: -1 --->
+<!--- @@Viewstack: any --->
 
 <h1>Look for Cloudinary Links in RichText properties</h1>
 


### PR DESCRIPTION
added
`<!--- @@Viewstack: any --->`

Page:
/cloudinary/migrator/report-image?debug=1

Error:
This webskin (type:configCloudinary & webskin:displayPageReportImages) is not positioned in the view stack as body or any. - This webskin (type:configCloudinary & webskin:displayPageReportImages) is not positioned in the view stack as body or any.